### PR TITLE
Fix access to the X11 socket

### DIFF
--- a/org.kde.lokalize.json
+++ b/org.kde.lokalize.json
@@ -7,8 +7,7 @@
     "rename-icon": "lokalize",
     "finish-args": [
         "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
+        "--socket=x11",
         "--device=dri",
         "--filesystem=host",
         "--socket=pulseaudio"


### PR DESCRIPTION
On Wayland Lokalize runs in XWayland mode, so we need to give it access to x11, not fallback-x11

Fixes https://bugs.kde.org/show_bug.cgi?id=496202